### PR TITLE
Update repository URLs and publisher information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Development Container Templates
+# RSM Dev Container Templates
+
+This repo is based on the [Dev Container Template Starter](https://github.com/devcontainers/template-starter) and the [Dev Container Template specification](https://containers.dev/implementors/templates-distribution/#distribution) and will be updated with templates that are applicable to the work we do as a team.
 
 <table style="width: 100%; border-style: none;"><tr>
 <td style="width: 140px; text-align: center;"><a href="https://github.com/devcontainers"><img width="128px" src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/78c9587b995299d5bfc007a0077773556ecb0994/assets/Cube/SVG/ic_fluent_cube_32_filled.svg" alt="devcontainers organization logo"/></a></td>
@@ -16,7 +18,7 @@ This repository contains a set of **Dev Container Templates** which are source f
 
 - [`src`](src) - A collection of subfolders, each declaring a template. Each subfolder contains at least a
     `devcontainer-template.json` and a [devcontainer.json](https://containers.dev/implementors/json_reference/).
-- [`test`](test) - Mirroring `src`, a folder-per-template with at least a `test.sh` script. These tests are executed by the [CI](https://github.com/myty/devcontainer-templates/blob/main/.github/workflows/test-pr.yaml).
+- [`test`](test) - Mirroring `src`, a folder-per-template with at least a `test.sh` script. These tests are executed by the [CI](https://github.com/rsm-hcd/devcontainer-templates/blob/main/.github/workflows/test-pr.yaml).
 
 ## Contributions
 
@@ -33,7 +35,7 @@ This repository will accept improvement and bug fix contributions related to the
 
 ## Feedback
 
-Issues related to these templates can be reported in [an issue](https://github.com/myty/devcontainer-templates/issues) in this repository.
+Issues related to these templates can be reported in [an issue](https://github.com/rsm-hcd/devcontainer-templates/issues) in this repository.
 
 ## License
 

--- a/src/deno/README.md
+++ b/src/deno/README.md
@@ -17,4 +17,4 @@ This template references an image that was [pre-built](https://containers.dev/im
 
 ---
 
-_Note: This file was auto-generated from the [devcontainer-template.json](https://github.com/myty/devcontainer-templates/blob/main/src/deno/devcontainer-template.json).  Add additional notes to a `NOTES.md`._
+_Note: This file was auto-generated from the [devcontainer-template.json](https://github.com/rsm-hcd/devcontainer-templates/blob/main/src/deno/devcontainer-template.json).  Add additional notes to a `NOTES.md`._

--- a/src/deno/devcontainer-template.json
+++ b/src/deno/devcontainer-template.json
@@ -3,9 +3,9 @@
 	"version": "0.1.0",
 	"name": "Deno",
 	"description": "Develop Deno based applications. Includes Deno, Node.js, npm, etc.",
-	"documentationURL": "https://github.com/myty/devcontainer-templates/tree/main/src/deno",
-	"publisher": "Michael Tyson (@myty)",
-	"licenseURL": "https://github.com/myty/devcontainer-templates/blob/main/LICENSE",
+	"documentationURL": "https://github.com/rsm-hcd/devcontainer-templates/tree/main/src/deno",
+	"publisher": "RSM - Human-Centered Engineering (@rsm-hcd)",
+	"licenseURL": "https://github.com/rsm-hcd/devcontainer-templates/blob/main/LICENSE",
 	"options": {
 		"denoVersion": {
 			"type": "string",


### PR DESCRIPTION
This completes the transition to the RSM HCD Engineering org with updated documentation and template config