### PR TITLE
KITCHEN-1418 Add deno-postgres template

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -13,6 +13,7 @@ jobs:
         with:
           filters: |
             deno: ./**/deno/**
+            deno-postgres: ./**/deno-postgres/**
 
   test:
     needs: [detect-changes]

--- a/src/deno-postgres/.devcontainer/Dockerfile
+++ b/src/deno-postgres/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM denoland/deno:bin-${templateOption:denoVersion} AS deno
+FROM mcr.microsoft.com/devcontainers/typescript-node:20
+COPY --from=deno /deno /usr/local/bin/deno

--- a/src/deno-postgres/.devcontainer/devcontainer.json
+++ b/src/deno-postgres/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+	"name": "Deno & PostgreSQL",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5000, 5001, 5432],
+	// "portsAttributes": {
+	//		"5001": {
+	//			"protocol": "https"
+	//		}
+	// }
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"justjavac.vscode-deno-extensionpack"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/src/deno-postgres/.devcontainer/docker-compose.yml
+++ b/src/deno-postgres/.devcontainer/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.8'
 services:
-  devcontainer:
+  app:
+    build:
       context: .
       dockerfile: Dockerfile
 

--- a/src/deno-postgres/.devcontainer/docker-compose.yml
+++ b/src/deno-postgres/.devcontainer/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+services:
+  devcontainer:
+      context: .
+      dockerfile: Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    # user: root
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: postgres:${templateOption:postgresVersion}
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  postgres-data:

--- a/src/deno-postgres/NOTES.md
+++ b/src/deno-postgres/NOTES.md
@@ -1,0 +1,35 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/typescript-node ([source](https://github.com/devcontainers/images/tree/main/src/typescript-node))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/typescript-node/.devcontainer/devcontainer.json))
+
+## Using this template
+
+This definition creates two containers, one for Deno and one for PostgreSQL. You will be connected to the Deno container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `docker-compose.yml`. Data is stored in a volume named `postgres-data`.
+
+While the definition itself works unmodified, it uses `mcr.microsoft.com/devcontainers/typescript-node` as a base image which includes `git`, `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
+
+You also can connect to PostgreSQL from an external tool when connected to the Dev Contaner from a local tool  by updating `.devcontainer/devcontainer.json` as follows:
+
+```json
+"forwardPorts": [ "5432" ]
+```
+
+### Adding another service
+
+You can add other services to your `docker-compose.yml` file [as described in Docker's documentaiton](https://docs.docker.com/compose/compose-file/#service-configuration-reference). However, if you want anything running in this service to be available in the container on localhost, or want to forward the service locally, be sure to add this line to the service config:
+
+```yaml
+# Runs the service on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+network_mode: service:db
+```
+
+### Using the forwardPorts property
+
+By default, web frameworks and tools often only listen to localhost inside the container. As a result, we recommend using the `forwardPorts` property to make these ports available locally.
+
+```json
+"forwardPorts": [9000]
+```
+
+The `ports` property in `docker-compose.yml` [publishes](https://docs.docker.com/config/containers/container-networking/#published-ports) rather than forwards the port. This will not work in a cloud environment like Codespaces and applications need to listen to `*` or `0.0.0.0` for the application to be accessible externally. Fortunately the `forwardPorts` property does not have this limitation.

--- a/src/deno-postgres/devcontainer-template.json
+++ b/src/deno-postgres/devcontainer-template.json
@@ -1,0 +1,34 @@
+{
+	"id": "deno-postgres",
+	"version": "0.1.0",
+	"name": "Deno",
+	"description": "Develop Deno+Postgres based applications. Includes Deno, Postgres, Node.js, npm, etc.",
+	"documentationURL": "https://github.com/rsm-hcd/devcontainer-templates/tree/main/src/deno",
+	"publisher": "RSM - Human-Centered Engineering (@rsm-hcd)",
+	"licenseURL": "https://github.com/rsm-hcd/devcontainer-templates/blob/main/LICENSE",
+	"options": {
+		"denoVersion": {
+			"type": "string",
+			"description": "Deno version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
+			"proposals": [
+				"1.40.2",
+				"1.39.4",
+				"1.38.5"
+			],
+			"default": "1.40.2"
+		},
+		"postgresVersion": {
+			"type": "string",
+			"description": "Postgres version:",
+			"proposals": [
+				"16",
+				"15",
+				"14"
+			],
+			"default": "16"
+		}
+	},
+	"platforms": [
+		"Deno"
+	]
+}

--- a/src/deno-postgres/devcontainer-template.json
+++ b/src/deno-postgres/devcontainer-template.json
@@ -29,6 +29,7 @@
 		}
 	},
 	"platforms": [
-		"Deno"
+		"Deno",
+		"PostgreSQL"
 	]
 }

--- a/test/deno-postgres/main_test.ts
+++ b/test/deno-postgres/main_test.ts
@@ -1,0 +1,29 @@
+import { Pool } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
+
+Deno.test("database", async () => {
+  // Get the connection string from the environment variable "DATABASE_URL"
+  const databaseUrl =
+    "postgres://postgres:postgres@db:5432/postgres?sslmode=disable";
+
+  // Create a database pool with three connections that are lazily established
+  const pool = new Pool(databaseUrl, 3, true);
+
+  // Connect to the database
+  const connection = await pool.connect();
+
+  try {
+    // Create the table
+    await connection.queryObject`
+      CREATE TABLE IF NOT EXISTS todos (
+        id SERIAL PRIMARY KEY,
+        title TEXT NOT NULL
+      )
+    `;
+  } finally {
+    // Release the connection back into the pool
+    connection.release();
+  }
+
+  await pool.end();
+});
+

--- a/test/deno-postgres/test.sh
+++ b/test/deno-postgres/test.sh
@@ -6,7 +6,7 @@ source test-utils.sh
 check "distro" lsb_release -c
 
 # Image specific tests
-check "deno" deno test
+check "deno-postgres" deno test -A
 
 # Report result
 reportResults

--- a/test/deno/main.ts
+++ b/test/deno/main.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b;
+}

--- a/test/deno/main_test.ts
+++ b/test/deno/main_test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from "https://deno.land/std@0.213.0/assert/mod.ts";
+import { add } from "./main.ts";
+
+Deno.test(function addTest() {
+  assertEquals(add(2, 3), 5);
+});


### PR DESCRIPTION
Adds the deno-postgres template along with tests that ensure that deno runs and can connect to the postgres database. Also, updated the test for deno.